### PR TITLE
#292 Changed path to istio-virtual-service.yaml in pipelines

### DIFF
--- a/pipelines/Jenkinsfile.evaluation_done
+++ b/pipelines/Jenkinsfile.evaluation_done
@@ -77,9 +77,9 @@ pipeline {
                 sh "git clone https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${env.GITHUBORG}/${env.PROJECT}"
                 sh "cd ${env.PROJECT} && git checkout ${env.STAGE}"
 
-                sh "cd ${env.PROJECT} && sed -i \"s#weight: 0#weight: swap_100#\" helm-chart/templates/istio-virtual-service-${env.SERVICE}.yaml"
-                sh "cd ${env.PROJECT} && sed -i \"s#weight: 100#weight: 0#\" helm-chart/templates/istio-virtual-service-${env.SERVICE}.yaml"
-                sh "cd ${env.PROJECT} && sed -i \"s#weight: swap_100#weight: 100#\" helm-chart/templates/istio-virtual-service-${env.SERVICE}.yaml"
+                sh "cd ${env.PROJECT} && sed -i \"s#weight: 0#weight: swap_100#\" helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml"
+                sh "cd ${env.PROJECT} && sed -i \"s#weight: 100#weight: 0#\" helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml"
+                sh "cd ${env.PROJECT} && sed -i \"s#weight: swap_100#weight: 100#\" helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml"
 
                 sh "cd ${env.PROJECT} && git add ."
                 sh "cd ${env.PROJECT} && git commit -am '[keptn]: Switched blue green due to failed evaluation.'"

--- a/pipelines/Jenkinsfile.run_tests
+++ b/pipelines/Jenkinsfile.run_tests
@@ -212,9 +212,9 @@ pipeline {
               sh "git clone https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${env.GITHUBORG}/${env.PROJECT}"
               sh "cd ${env.PROJECT} && git checkout ${env.STAGE}"
 
-              sh "cd ${env.PROJECT} && sed -i \"s#weight: 0#weight: swap_100#\" helm-chart/templates/istio-virtual-service-${env.SERVICE}.yaml"
-              sh "cd ${env.PROJECT} && sed -i \"s#weight: 100#weight: 0#\" helm-chart/templates/istio-virtual-service-${env.SERVICE}.yaml"
-              sh "cd ${env.PROJECT} && sed -i \"s#weight: swap_100#weight: 100#\" helm-chart/templates/istio-virtual-service-${env.SERVICE}.yaml"
+              sh "cd ${env.PROJECT} && sed -i \"s#weight: 0#weight: swap_100#\" helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml"
+              sh "cd ${env.PROJECT} && sed -i \"s#weight: 100#weight: 0#\" helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml"
+              sh "cd ${env.PROJECT} && sed -i \"s#weight: swap_100#weight: 100#\" helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml"
 
               sh "cd ${env.PROJECT} && git add ."
               sh "cd ${env.PROJECT} && git commit -am '[keptn]: Switched blue green due to failed evaluation.'"


### PR DESCRIPTION
This PR contains one change in two pipelines: Jenkinsfile.evaluation_done & Jenkinsfile_run_tests.

When there is the need to change the virtual-service configuration of a service (e.g., for a roll-back), both pipelines are now looking for a istio-virtual-service file that follows the naming pattern servicename-servicetype.yaml

This version of the jenkins-service builds on the newest version of the github-service.