### PR TITLE
#229 Namespace have project name as prefix

### DIFF
--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -79,7 +79,7 @@ pipeline {
           script {
             tagMatchRules[0].tags[0].value = "${env.PROJECT}"
             tagMatchRules[0].tags[1].value = "${env.SERVICE}"
-            tagMatchRules[0].tags[2].value = "${env.STAGE}"
+            tagMatchRules[0].tags[2].value = "${env.PROJECT}-${env.STAGE}"
             
             if (env.DT_TENANT_URL) {
               String dtTenant = "${env.DT_TENANT_URL}"

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -55,7 +55,7 @@ pipeline {
         container('helm') {
           sh "helm init --client-only"
           sh "cd ${env.PROJECT} && helm dep update helm-chart/"
-          sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.STAGE}"
+          sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --recreate-pods"
         }
       }
     }
@@ -69,7 +69,7 @@ pipeline {
         container('helm') {
           sh "helm init --client-only"
           sh "cd ${env.PROJECT} && helm dep update helm-chart/"
-          sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.STAGE} --recreate-pods"
+          sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --recreate-pods"
         }
       }
     }

--- a/pipelines/Jenkinsfile.run_tests
+++ b/pipelines/Jenkinsfile.run_tests
@@ -51,7 +51,7 @@ pipeline {
             if ( env.DEPLOYMENTSTRATEGY ==~ 'blue_green_service' ) {
               def status_blue = waitForDeployment (
                 deploymentName: "${env.SERVICE}-blue",
-                environment: "${env.STAGE}"
+                environment: "${env.PROJECT}-${env.STAGE}"
               )
               if(status_blue !=0 ){
                 currentBuild.result = 'FAILED'
@@ -60,7 +60,7 @@ pipeline {
               
               def status_green = waitForDeployment (
                 deploymentName: "${env.SERVICE}-green",
-                environment: "${env.STAGE}"
+                environment: "${env.PROJECT}-${env.STAGE}"
               )
               if(status_green !=0 ){
                 currentBuild.result = 'FAILED'
@@ -69,7 +69,7 @@ pipeline {
             } else {
               def status = waitForDeployment (
                 deploymentName: "${env.SERVICE}",
-                environment: "${env.STAGE}"
+                environment: "${env.PROJECT}-${env.STAGE}"
               )
               if(status !=0 ){
                 currentBuild.result = 'FAILED'
@@ -88,7 +88,7 @@ pipeline {
             def status = executeJMeter ( 
               scriptName: "${env.SERVICE}/jmeter/basiccheck.jmx", 
               resultsDir: "HealthCheck_${env.SERVICE}",
-              serverUrl: "${env.SERVICE}.${env.STAGE}", 
+              serverUrl: "${env.SERVICE}.${env.PROJECT}-${env.STAGE}", 
               serverPort: 80,
               checkPath: '/health',
               vuCount: 1,
@@ -121,7 +121,7 @@ pipeline {
             def status = executeJMeter (
               scriptName: "${env.SERVICE}/jmeter/${env.SERVICE}_load.jmx", 
               resultsDir: "FuncCheck_${env.SERVICE}",
-              serverUrl: "${env.SERVICE}.${env.STAGE}.svc.cluster.local", 
+              serverUrl: "${env.SERVICE}.${env.PROJECT}-${env.STAGE}.svc.cluster.local", 
               serverPort: 80,
               checkPath: '/health',
               vuCount: 1,
@@ -161,7 +161,7 @@ pipeline {
               def status = executeJMeter (
                 scriptName: "${env.SERVICE}/jmeter/${env.SERVICE}_load.jmx", 
                 resultsDir: "PerfCheck_${env.SERVICE}",
-                serverUrl: "${env.SERVICE}.${env.STAGE}.${GATEWAY}", 
+                serverUrl: "${env.SERVICE}.${env.PROJECT}-${env.STAGE}.${GATEWAY}", 
                 serverPort: 80,
                 checkPath: '/health',
                 vuCount: 10,


### PR DESCRIPTION
The K8s namespaces are now created based on project name and stage name:

![Capture](https://user-images.githubusercontent.com/729071/57509199-e5dbe380-7303-11e9-9f5c-9ea468a66d50.PNG)

- [x]  DT events are send correctly to Dynatrace tenant (when Dynatrace monitoring is active)
- [x]  Self-healing use cases also sends a DT event that is adapted according to the new namespace name