### PR TITLE
Check of DT_TENANT_URL in pipelines

### DIFF
--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -81,7 +81,7 @@ pipeline {
             tagMatchRules[0].tags[1].value = "${env.SERVICE}"
             tagMatchRules[0].tags[2].value = "${env.PROJECT}-${env.STAGE}"
             
-            if (env.DT_TENANT_URL) {
+            if (env.DT_TENANT_URL && env.DT_API_TOKEN) {
               String dtTenant = "${env.DT_TENANT_URL}"
 
               if (dtTenant != null && dtTenant != "") {
@@ -107,7 +107,7 @@ pipeline {
                 println "Value of DT_TENANT_URL is empty, do not send event."
               }
             } else {
-              println "No DT_TENANT_URL available, do not send event."
+              println "DT_TENANT_URL or DT_API_TOKEN not set, do not send event."
             }
           }
         }

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -84,7 +84,7 @@ pipeline {
             if (env.DT_TENANT_URL) {
               String dtTenant = "${env.DT_TENANT_URL}"
 
-              if (dtTenant != null && (dtTenant.endsWith("dynatrace.com") || dtTenant.endsWith("dynatrace.com/"))) {
+              if (dtTenant != null && dtTenant != "") {
                 def status = pushDynatraceDeploymentEvent (
                   tagRule : tagMatchRules,
                   deploymentVersion : "${env.TAG}",
@@ -104,7 +104,7 @@ pipeline {
                   ]
                 )
               } else {
-                println "Value of DT_TENANT_URL not valid, do not send event."
+                println "Value of DT_TENANT_URL is empty, do not send event."
               }
             } else {
               println "No DT_TENANT_URL available, do not send event."

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -83,8 +83,9 @@ pipeline {
             
             if (env.DT_TENANT_URL && env.DT_API_TOKEN) {
               String dtTenant = "${env.DT_TENANT_URL}"
+              String apiToken = "${env.DT_API_TOKEN}"
 
-              if (dtTenant != null && dtTenant != "") {
+              if (dtTenant != "" && apiToken != "") {
                 def status = pushDynatraceDeploymentEvent (
                   tagRule : tagMatchRules,
                   deploymentVersion : "${env.TAG}",
@@ -104,7 +105,7 @@ pipeline {
                   ]
                 )
               } else {
-                println "Value of DT_TENANT_URL is empty, do not send event."
+                println "Value of DT_TENANT_URL or DT_API_TOKEN is empty, do not send event."
               }
             } else {
               println "DT_TENANT_URL or DT_API_TOKEN not set, do not send event."


### PR DESCRIPTION
To support Dynatrace managed, the check of the DT_TEANT_URL can be restricted to dynatrace.live.com.