### PR TITLE
#268 Removed dependency to Dynatrace

### DIFF
--- a/docker-jenkins/jenkins.sh
+++ b/docker-jenkins/jenkins.sh
@@ -11,7 +11,6 @@ cat $JENKINS_HOME/MANIFEST
 sed -i 's/DOCKER_REGISTRY_URL_PLACEHOLDER/'"$DOCKER_REGISTRY_IP"'/' $JENKINS_HOME/config.xml
 sed -i 's/GITHUB_USER_EMAIL_PLACEHOLDER/'"$GITHUB_USER_EMAIL"'/' $JENKINS_HOME/config.xml
 sed -i 's/GITHUB_ORGANIZATION_PLACEHOLDER/'"$GITHUB_ORGANIZATION"'/' $JENKINS_HOME/config.xml
-sed -i 's~DT_TENANT_URL_PLACEHOLDER~'"$DT_TENANT_URL"'~' $JENKINS_HOME/de.tsystems.mms.apm.performancesignature.dynatracesaas.DynatraceGlobalConfiguration.xml
 
 # if `docker run` first argument start with `--` the user is passing jenkins launcher arguments
 if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -73,47 +73,6 @@ pipeline {
         }
       }
     }
-    stage('DT deploy event') {
-      steps {
-        container("curl") {
-          script {
-            tagMatchRules[0].tags[0].value = "${env.PROJECT}"
-            tagMatchRules[0].tags[1].value = "${env.SERVICE}"
-            tagMatchRules[0].tags[2].value = "${env.PROJECT}-${env.STAGE}"
-            
-            if (env.DT_TENANT_URL && env.DT_API_TOKEN) {
-              String dtTenant = "${env.DT_TENANT_URL}"
-              String apiToken = "${env.DT_API_TOKEN}"
-
-              if (dtTenant != "" && apiToken != "") {
-                def status = pushDynatraceDeploymentEvent (
-                  tagRule : tagMatchRules,
-                  deploymentVersion : "${env.TAG}",
-                  deploymentName : "Deploy ${env.SERVICE} (${env.TAG}) with strategy ${env.DEPLOYMENTSTRATEGY}",
-                  deploymentProject : "${env.PROJECT}", 
-                  customProperties : [
-                    [key: 'Jenkins build number', value: "${env.BUILD_ID}"],
-                    [key: 'GitHub org', value: "${env.GITHUBORG}"],
-                    [key: 'Project', value: "${env.PROJECT}"],
-                    [key: 'Test strategy', value: "${env.TESTSTRATEGY}"],
-                    [key: 'Deployment strategy', value: "${env.DEPLOYMENTSTRATEGY}"],
-                    [key: 'Stage', value: "${env.STAGE}"],
-                    [key: 'Service', value: "${env.SERVICE}"],
-                    [key: 'Image', value: "${env.IMAGE}"],
-                    [key: 'Tag', value: "${env.TAG}"],
-                    [key: 'keptn context', value: "${env.KEPTNCONTEXT}"]  
-                  ]
-                )
-              } else {
-                println "Value of DT_TENANT_URL or DT_API_TOKEN is empty, do not send event."
-              }
-            } else {
-              println "DT_TENANT_URL or DT_API_TOKEN not set, do not send event."
-            }
-          }
-        }
-      }
-    }
     stage('Send keptn event') {
       steps {
         container("curl") {

--- a/releasenotes/releasenotes_V0.2.1.md
+++ b/releasenotes/releasenotes_V0.2.1.md
@@ -2,8 +2,9 @@
 
 ## New Features
 - The name of the namespace has the project name as prefix, e.g., sockshop-dev, sockshop-production [#229](https://github.com/keptn/keptn/issues/229)
+- The *deploy* pipeline does not send the Dynatrace deployment event since this is handled by the dynatrace-service now [#268](https://github.com/keptn/keptn/issues/268)
 
 ## Fixed Issues
-- Bugfix in roll-back step of evalution_done and run_tests pipelines [#292](https://github.com/keptn/keptn/issues/292)
+- Bugfix in roll-back step of *evalution_done* and *run_tests* pipelines [#292](https://github.com/keptn/keptn/issues/292)
 
 ## Known Limitations


### PR DESCRIPTION
Due to the new dynatrace-service, sending Dynatrace events is not done in the Jenkins pipelines anymore. 