### PR TITLE
#332 Fix no healthy upstream-problem during b/g deployment

### DIFF
--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -55,13 +55,6 @@ pipeline {
         container('helm') {
           script {
             sh "helm init --client-only"
-
-            sh "find ${env.PROJECT}/helm-chart -name '*istio-virtual-service*' -print > istioFiles"
-            for (String file : readFile('istioFiles').split()) {
-              String mvCmd = "mv " + file + " " + "${env.PROJECT}" + "/helm-chart/templates"
-              println mvCmd
-            }
-
             sh "cd ${env.PROJECT} && helm dep update helm-chart/"
             sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
           }
@@ -82,7 +75,7 @@ pipeline {
 
             sh "find ${env.PROJECT}/helm-chart/templates -name '*istio-virtual-service*' -print > istioFiles"
             for (String file : readFile('istioFiles').split()) {
-              String mvCmd = "mv " + foundFiles + " " + "${env.PROJECT}" + "/helm-chart/"
+              String mvCmd = "mv " + files + " " + "${env.PROJECT}" + "/helm-chart/"
               println mvCmd
               sh(script: mvCmd)
             }
@@ -90,7 +83,7 @@ pipeline {
 
             sh "find ${env.PROJECT}/helm-chart -name '*istio-virtual-service*' -print > istioFiles"
             for (String file : readFile('istioFiles').split()) {
-              String mvCmd = "mv " + file + " " + "${env.PROJECT}" + "/helm-chart/templates"
+              String mvCmd = "mv " + file + " " + "${env.PROJECT}" + "/helm-chart/templates/"
               println mvCmd
               sh(script: mvCmd)
             }

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -66,8 +66,15 @@ pipeline {
         }
       }      
       steps {
+        container('yq') {
+            sh "COLOR1=$(cat carts-istio-virtual-service.yaml | yq r - spec.http[0].route[0].destination.subset)"
+            sh "WEIGHT1=$(cat carts-istio-virtual-service.yaml | yq r - spec.http[0].route[0].weight)"
+            sh "COLOR2=$(cat carts-istio-virtual-service.yaml | yq r - spec.http[0].route[1].destination.subset)"
+            sh "WEIGHT2=$(cat carts-istio-virtual-service.yaml | yq r - spec.http[0].route[1].weight)"
+        }
+
         container('kubectl') {
-          sh "echo ${env.PROJECT}"
+            sh "if [ $WEIGHT1 == "100" ]; then echo "Delete doployment of" $COLOR1; echo "Service=" ${env.SERVICE}; elif [$WEIGHT2 == "100" ]; then echo "Delete doployment of" $COLOR2; echo "Service=" ${env.SERVICE}; else  echo "This case must not happen!"; fi"
         }
         container('helm') {        
           sh "helm init --client-only"          

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -79,9 +79,13 @@ pipeline {
         container('kubectl') {
             script {
                 if (readFile('w1').trim() == "100") {
-                    println "Delete doployment of " + "${env.SERVICE}" + readFile('c1').trim()
+                    println "Delete doployment of " + "${env.SERVICE}" + "-" + readFile('c1').trim() " in namespace " + "${env.PROJECT}-${env.STAGE}"
+                    String cmd = "kubectl delete deployment " + "${env.SERVICE}" + "-" + readFile('c1').trim() + " --namespace " + "${env.PROJECT}-${env.STAGE}"
+                    sh(script: cmd)
                 } else if (readFile('w2').trim() == "100") {
-                    println "Delete doployment of " + "${env.SERVICE}" + readFile('c2').trim()
+                    println "Delete doployment of " + "${env.SERVICE}" + "-" + readFile('c2').trim() " in namespace " + "${env.PROJECT}-${env.STAGE}"
+                    String cmd = "kubectl delete deployment " + "${env.SERVICE}" + "-" + readFile('c1').trim() + " --namespace " + "${env.PROJECT}-${env.STAGE}"
+                    sh(script: cmd)
                 } else {
                     println "This case must not happen!"
                 }

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -80,7 +80,16 @@ pipeline {
               sh(script: mvCmd)
             }
             sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
-
+          }
+        }
+        container('kubectl') {    
+          script {
+            sh "kubectl rollout status deployment/" + "${env.SERVICE}" + "-blue" + " --namespace " + "${env.PROJECT}-${env.STAGE}"
+            sh "kubectl rollout status deployment/" + "${env.SERVICE}" + "-green" + " --namespace " + "${env.PROJECT}-${env.STAGE}"
+          }
+        }
+        container('helm') {    
+          script {
             sh "find ${env.PROJECT}/helm-chart -name '*istio-virtual-service*' -print > istioVSFiles"
             for (String file : readFile('istioVSFiles').split()) {
               String mvCmd = "mv " + file + " " + "${env.PROJECT}" + "/helm-chart/templates/"

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -66,34 +66,14 @@ pipeline {
         }
       }      
       steps {
-        container('yq') {
-            script {
-                sh "cat ${env.PROJECT}/helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml > vs"
-                sh "yq r vs spec.http[0].route[0].destination.subset > c1"
-                sh "yq r vs spec.http[0].route[0].weight > w1"
-                sh "yq r vs spec.http[0].route[1].destination.subset > c2"
-                sh "yq r vs spec.http[0].route[1].weight > w2"
-            }
-        }
-
-        container('kubectl') {
-            script {
-                if (readFile('w1').trim() == "100") {
-                    println "Delete doployment of " + "${env.SERVICE}" + "-" + readFile('c1').trim() + " in namespace " + "${env.PROJECT}-${env.STAGE}"
-                    String cmd = "kubectl delete deployment " + "${env.SERVICE}" + "-" + readFile('c1').trim() + " --namespace " + "${env.PROJECT}-${env.STAGE}"
-                    sh(script: cmd)
-                } else if (readFile('w2').trim() == "100") {
-                    println "Delete doployment of " + "${env.SERVICE}" + "-" + readFile('c2').trim() + " in namespace " + "${env.PROJECT}-${env.STAGE}"
-                    String cmd = "kubectl delete deployment " + "${env.SERVICE}" + "-" + readFile('c1').trim() + " --namespace " + "${env.PROJECT}-${env.STAGE}"
-                    sh(script: cmd)
-                } else {
-                    println "This case must not happen!"
-                }
-            }
-        }
         container('helm') {        
-          sh "helm init --client-only"          
+          sh "helm init --client-only"
           sh "cd ${env.PROJECT} && helm dep update helm-chart/"
+          
+          sh "cd ${env.PROJECT}/helm-chart/templates && find . -name '*istio-virtual-service*' -exec mv {} ../ \;"
+          sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
+          
+          sh "cd ${env.PROJECT}/helm-chart && find . -name '*istio-virtual-service*' -exec mv {} ./templates \;"
           sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
         }
       }

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -79,7 +79,7 @@ pipeline {
               println mvCmd
               sh(script: mvCmd)
             }
-            sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
+            sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait --reuse-values"
           }
         }
         container('kubectl') {    
@@ -96,7 +96,7 @@ pipeline {
               println mvCmd
               sh(script: mvCmd)
             }
-            sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
+            sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait --reuse-values"
           }
         }
       }

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -54,9 +54,10 @@ pipeline {
       steps {
         container('helm') {
           sh "helm init --client-only"
-          final foundFiles = sh(script: "find ${env.PROJECT}/helm-chart/templates -name '*istio-virtual-service*' -print", returnStdout: true).split()
-          for (String file : foundFiles) {
-            String mvCmd = "mv " + foundFiles + " " + "${env.PROJECT}" + "/helm-chart/"
+          
+          sh "find ${env.PROJECT}/helm-chart -name '*istio-virtual-service*' -print > istioFiles"
+          for (String file : readFile('istioFiles').split()) {
+            String mvCmd = "mv " + file + " " + "${env.PROJECT}" + "/helm-chart/templates"
             println mvCmd
           }
             
@@ -77,22 +78,20 @@ pipeline {
             sh "helm init --client-only"
             sh "cd ${env.PROJECT} && helm dep update helm-chart/"
 
-            final foundFiles = sh(script: "find ${env.PROJECT}/helm-chart/templates -name '*istio-virtual-service*' -print", returnStdout: true).split()
-            for (String file : foundFiles) {
+            sh "find ${env.PROJECT}/helm-chart/templates -name '*istio-virtual-service*' -print > istioFiles"
+            for (String file : readFile('istioFiles').split()) {
               String mvCmd = "mv " + foundFiles + " " + "${env.PROJECT}" + "/helm-chart/"
               println mvCmd
               sh(script: mvCmd)
             }
-
             sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
 
-            final foundFilesTmp = sh(script: "find ${env.PROJECT}/helm-chart -name '*istio-virtual-service*' -print", returnStdout: true).split()
-            for (String file : foundFilesTmp) {
+            sh "find ${env.PROJECT}/helm-chart -name '*istio-virtual-service*' -print > istioFiles"
+            for (String file : readFile('istioFiles').split()) {
               String mvCmd = "mv " + file + " " + "${env.PROJECT}" + "/helm-chart/templates"
               println mvCmd
               sh(script: mvCmd)
             }
-
             sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
           }
         }

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -67,10 +67,10 @@ pipeline {
       }      
       steps {
         container('yq') {
-            sh "echo "COLOR1" $(cat carts-istio-virtual-service.yaml | yq r - spec.http[0].route[0].destination.subset)"
-            sh "echo "WEIGHT1" $(cat carts-istio-virtual-service.yaml | yq r - spec.http[0].route[0].weight)"
-            sh "echo "COLOR2" $(cat carts-istio-virtual-service.yaml | yq r - spec.http[0].route[1].destination.subset)"
-            sh "echo "WEIGHT2" $(cat carts-istio-virtual-service.yaml | yq r - spec.http[0].route[1].weight)"
+            sh "cat carts-istio-virtual-service.yaml | yq r - spec.http[0].route[0].destination.subset"
+            sh "cat carts-istio-virtual-service.yaml | yq r - spec.http[0].route[0].weight"
+            sh "cat carts-istio-virtual-service.yaml | yq r - spec.http[0].route[1].destination.subset"
+            sh "cat carts-istio-virtual-service.yaml | yq r - spec.http[0].route[1].weight"
         }
 
         container('kubectl') {

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -33,7 +33,12 @@ pipeline {
     label 'kubegit'
   }
   stages {
-    stage('Checkout configuration') {
+    stage('Deploy service - direct') {
+      when {
+        expression {
+          return env.DEPLOYMENTSTRATEGY ==~ 'direct' 
+        }
+      }
       steps {
         container('git') {
           withCredentials([usernamePassword(credentialsId: 'git-credentials-acm', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
@@ -43,15 +48,6 @@ pipeline {
             sh "cd ${env.PROJECT} && git checkout ${env.STAGE}"
           }
         }
-      }
-    }
-    stage('Deploy service - direct') {
-      when {
-        expression {
-          return env.DEPLOYMENTSTRATEGY ==~ 'direct' 
-        }
-      }
-      steps {
         container('helm') {
           script {
             sh "helm init --client-only"
@@ -66,20 +62,22 @@ pipeline {
         expression {
           return env.DEPLOYMENTSTRATEGY ==~ 'blue_green_service' 
         }
-      }      
+      }
       steps {
+        container('git') {
+          withCredentials([usernamePassword(credentialsId: 'git-credentials-acm', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
+            sh "rm -rf ${env.PROJECT}"
+            sh "git config --global user.email ${env.GITHUB_USER_EMAIL}"
+            sh "git clone https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${env.GITHUBORG}/${env.PROJECT}"
+            sh "cd ${env.PROJECT} && git checkout ${env.STAGE}"
+            sh "cd ${env.PROJECT} && git reset --hard HEAD~1"
+          }
+        }
         container('helm') {    
           script {
             sh "helm init --client-only"
             sh "cd ${env.PROJECT} && helm dep update helm-chart/"
-
-            sh "find ${env.PROJECT}/helm-chart/templates -name '*istio-virtual-service*' -print > istioVSFiles"
-            for (String file : readFile('istioVSFiles').split()) {
-              String mvCmd = "mv " + file + " " + "${env.PROJECT}" + "/helm-chart/"
-              println mvCmd
-              sh(script: mvCmd)
-            }
-            sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait --reuse-values"
+            sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
           }
         }
         container('kubectl') {    
@@ -88,15 +86,14 @@ pipeline {
             sh "kubectl rollout status deployment/" + "${env.SERVICE}" + "-green" + " --namespace " + "${env.PROJECT}-${env.STAGE}"
           }
         }
+        container('git') {
+          withCredentials([usernamePassword(credentialsId: 'git-credentials-acm', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
+            sh "cd ${env.PROJECT} && git pull"
+          }
+        }
         container('helm') {    
-          script {
-            sh "find ${env.PROJECT}/helm-chart -name '*istio-virtual-service*' -print > istioVSFiles"
-            for (String file : readFile('istioVSFiles').split()) {
-              String mvCmd = "mv " + file + " " + "${env.PROJECT}" + "/helm-chart/templates/"
-              println mvCmd
-              sh(script: mvCmd)
-            }
-            sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait --reuse-values"
+          script {            
+            sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
           }
         }
       }

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -66,13 +66,6 @@ pipeline {
         }
       }      
       steps {
-        container('yq') {
-            sh "cat ./helm-chart/templates/carts-istio-virtual-service.yaml | yq r - spec.http[0].route[0].destination.subset"
-            sh "cat ./helm-chart/templates/carts-istio-virtual-service.yaml | yq r - spec.http[0].route[0].weight"
-            sh "cat ./helm-chart/templates/carts-istio-virtual-service.yaml | yq r - spec.http[0].route[1].destination.subset"
-            sh "cat ./helm-chart/templates/carts-istio-virtual-service.yaml | yq r - spec.http[0].route[1].weight"
-        }
-
         container('kubectl') {
             sh "echo ${env.SERVICE}"
         }

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -54,6 +54,12 @@ pipeline {
       steps {
         container('helm') {
           sh "helm init --client-only"
+          final foundFiles = sh(script: "find ${env.PROJECT}/helm-chart/templates -name '*istio-virtual-service*' -print", returnStdout: true).split()
+          for (String file : foundFiles) {
+            String mvCmd = "mv " + foundFiles + " " + "${env.PROJECT}" + "/helm-chart/"
+            println mvCmd
+          }
+            
           sh "cd ${env.PROJECT} && helm dep update helm-chart/"
           sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
         }
@@ -71,7 +77,7 @@ pipeline {
             sh "helm init --client-only"
             sh "cd ${env.PROJECT} && helm dep update helm-chart/"
 
-            final foundFiles = sh(script: 'find ${env.PROJECT}/helm-chart/templates -name "*istio-virtual-service*" -print', returnStdout: true).split()
+            final foundFiles = sh(script: "find ${env.PROJECT}/helm-chart/templates -name '*istio-virtual-service*' -print", returnStdout: true).split()
             for (String file : foundFiles) {
               String mvCmd = "mv " + foundFiles + " " + "${env.PROJECT}" + "/helm-chart/"
               println mvCmd
@@ -80,7 +86,7 @@ pipeline {
 
             sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
 
-            final foundFilesTmp = sh(script: 'find ${env.PROJECT}/helm-chart -name "*istio-virtual-service*" -print', returnStdout: true).split()
+            final foundFilesTmp = sh(script: "find ${env.PROJECT}/helm-chart -name '*istio-virtual-service*' -print", returnStdout: true).split()
             for (String file : foundFilesTmp) {
               String mvCmd = "mv " + file + " " + "${env.PROJECT}" + "/helm-chart/templates"
               println mvCmd

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -68,13 +68,16 @@ pipeline {
       steps {
         container('yq') {
             script {
-                def c1 = sh(script: 'cat ${env.PROJECT}/helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml | yq r - spec.http[0].route[0].destination.subset', returnStdout: true)
-                def w1 = sh(script: 'cat ${env.PROJECT}/helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml | yq r - spec.http[0].route[0].weight', returnStdout: true)
-                def c2 = sh(script: 'cat ${env.PROJECT}/helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml | yq r - spec.http[0].route[1].destination.subset', returnStdout: true)
-                def w2 = sh(script: 'cat ${env.PROJECT}/helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml | yq r - spec.http[0].route[1].weight', returnStdout: true)
+                sh "pwd"
+                sh "echo ${env.PROJECT}/helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml"
+                sh "cat ${env.PROJECT}/helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml > vs"
+
+                def c1 = sh(script: 'yq r vs spec.http[0].route[0].destination.subset', returnStdout: true)
+                def w1 = sh(script: 'yq r vs spec.http[0].route[0].weight', returnStdout: true)
+                def c2 = sh(script: 'yq r vs spec.http[0].route[1].destination.subset', returnStdout: true)
+                def w2 = sh(script: 'yq r vs spec.http[0].route[1].weight', returnStdout: true)
             }
         }
-
         container('kubectl') {
             script {
                 if (w1 == "100") {

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -79,9 +79,9 @@ pipeline {
         container('kubectl') {
             script {
                 if (readFile('w1').trim() == "100") {
-                    println "Delete doployment of " + "${env.SERVICE}" + c1
+                    println "Delete doployment of " + "${env.SERVICE}" + readFile('c1').trim()
                 } else if (readFile('w2').trim() == "100") {
-                    println "Delete doployment of " + "${env.SERVICE}" + c2
+                    println "Delete doployment of " + "${env.SERVICE}" + readFile('c2').trim()
                 } else {
                     println "This case must not happen!"
                 }

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -66,27 +66,29 @@ pipeline {
         }
       }      
       steps {
-        container('helm') {        
-          sh "helm init --client-only"
-          sh "cd ${env.PROJECT} && helm dep update helm-chart/"
-          
-          final foundFiles = sh(script: 'find ${env.PROJECT}/helm-chart/templates -name '*istio-virtual-service*' -print', returnStdout: true).split()
-          for (String file : foundFiles) {
-            String mvCmd = "mv " + foundFiles + " " + "${env.PROJECT}" + "/helm-chart/"
-            println mvCmd
-            sh(script: mvCmd)
+        container('helm') {    
+          script {
+            sh "helm init --client-only"
+            sh "cd ${env.PROJECT} && helm dep update helm-chart/"
+
+            final foundFiles = sh(script: 'find ${env.PROJECT}/helm-chart/templates -name '*istio-virtual-service*' -print', returnStdout: true).split()
+            for (String file : foundFiles) {
+              String mvCmd = "mv " + foundFiles + " " + "${env.PROJECT}" + "/helm-chart/"
+              println mvCmd
+              sh(script: mvCmd)
+            }
+
+            sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
+
+            final foundFilesTmp = sh(script: 'find ${env.PROJECT}/helm-chart -name '*istio-virtual-service*' -print', returnStdout: true).split()
+            for (String file : foundFilesTmp) {
+              String mvCmd = "mv " + file + " " + "${env.PROJECT}" + "/helm-chart/templates"
+              println mvCmd
+              sh(script: mvCmd)
+            }
+
+            sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
           }
-          
-          sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
-          
-          final foundFilesTmp = sh(script: 'find ${env.PROJECT}/helm-chart -name '*istio-virtual-service*' -print', returnStdout: true).split()
-          for (String file : foundFilesTmp) {
-            String mvCmd = "mv " + file + " " + "${env.PROJECT}" + "/helm-chart/templates"
-            println mvCmd
-            sh(script: mvCmd)
-          }
-    
-          sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
         }
       }
     }

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -55,7 +55,7 @@ pipeline {
         container('helm') {
           sh "helm init --client-only"
           sh "cd ${env.PROJECT} && helm dep update helm-chart/"
-          sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE}" --wait
+          sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
         }
       }
     }
@@ -69,7 +69,7 @@ pipeline {
         container('helm') {
           sh "helm init --client-only"
           sh "cd ${env.PROJECT} && helm dep update helm-chart/"
-          sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE}" --wait
+          sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
         }
       }
     }

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -71,7 +71,7 @@ pipeline {
             sh "helm init --client-only"
             sh "cd ${env.PROJECT} && helm dep update helm-chart/"
 
-            final foundFiles = sh(script: 'find ${env.PROJECT}/helm-chart/templates -name '*istio-virtual-service*' -print', returnStdout: true).split()
+            final foundFiles = sh(script: 'find ${env.PROJECT}/helm-chart/templates -name "*istio-virtual-service*" -print', returnStdout: true).split()
             for (String file : foundFiles) {
               String mvCmd = "mv " + foundFiles + " " + "${env.PROJECT}" + "/helm-chart/"
               println mvCmd
@@ -80,7 +80,7 @@ pipeline {
 
             sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
 
-            final foundFilesTmp = sh(script: 'find ${env.PROJECT}/helm-chart -name '*istio-virtual-service*' -print', returnStdout: true).split()
+            final foundFilesTmp = sh(script: 'find ${env.PROJECT}/helm-chart -name "*istio-virtual-service*" -print', returnStdout: true).split()
             for (String file : foundFilesTmp) {
               String mvCmd = "mv " + file + " " + "${env.PROJECT}" + "/helm-chart/templates"
               println mvCmd

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -55,7 +55,7 @@ pipeline {
         container('helm') {
           sh "helm init --client-only"
           sh "cd ${env.PROJECT} && helm dep update helm-chart/"
-          sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE}"
+          sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE}" --wait
         }
       }
     }
@@ -69,7 +69,7 @@ pipeline {
         container('helm') {
           sh "helm init --client-only"
           sh "cd ${env.PROJECT} && helm dep update helm-chart/"
-          sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE}"
+          sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE}" --wait
         }
       }
     }

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -88,7 +88,7 @@ pipeline {
         }
         container('git') {
           withCredentials([usernamePassword(credentialsId: 'git-credentials-acm', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
-            sh "cd ${env.PROJECT} && git pull"
+            sh "cd ${env.PROJECT} && git reset --hard 'HEAD@{1}'"
           }
         }
         container('helm') {    

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -79,11 +79,11 @@ pipeline {
         container('kubectl') {
             script {
                 if (readFile('w1').trim() == "100") {
-                    println "Delete doployment of " + "${env.SERVICE}" + "-" + readFile('c1').trim() " in namespace " + "${env.PROJECT}-${env.STAGE}"
+                    println "Delete doployment of " + "${env.SERVICE}" + "-" + readFile('c1').trim() + " in namespace " + "${env.PROJECT}-${env.STAGE}"
                     String cmd = "kubectl delete deployment " + "${env.SERVICE}" + "-" + readFile('c1').trim() + " --namespace " + "${env.PROJECT}-${env.STAGE}"
                     sh(script: cmd)
                 } else if (readFile('w2').trim() == "100") {
-                    println "Delete doployment of " + "${env.SERVICE}" + "-" + readFile('c2').trim() " in namespace " + "${env.PROJECT}-${env.STAGE}"
+                    println "Delete doployment of " + "${env.SERVICE}" + "-" + readFile('c2').trim() + " in namespace " + "${env.PROJECT}-${env.STAGE}"
                     String cmd = "kubectl delete deployment " + "${env.SERVICE}" + "-" + readFile('c1').trim() + " --namespace " + "${env.PROJECT}-${env.STAGE}"
                     sh(script: cmd)
                 } else {

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -67,10 +67,10 @@ pipeline {
       }      
       steps {
         container('yq') {
-            sh "cat ./helm-chart/carts-istio-virtual-service.yaml | yq r - spec.http[0].route[0].destination.subset"
-            sh "cat ./helm-chart/carts-istio-virtual-service.yaml | yq r - spec.http[0].route[0].weight"
-            sh "cat ./helm-chart/carts-istio-virtual-service.yaml | yq r - spec.http[0].route[1].destination.subset"
-            sh "cat ./helm-chart/carts-istio-virtual-service.yaml | yq r - spec.http[0].route[1].weight"
+            sh "cat ./helm-chart/templates/carts-istio-virtual-service.yaml | yq r - spec.http[0].route[0].destination.subset"
+            sh "cat ./helm-chart/templates/carts-istio-virtual-service.yaml | yq r - spec.http[0].route[0].weight"
+            sh "cat ./helm-chart/templates/carts-istio-virtual-service.yaml | yq r - spec.http[0].route[1].destination.subset"
+            sh "cat ./helm-chart/templates/carts-istio-virtual-service.yaml | yq r - spec.http[0].route[1].weight"
         }
 
         container('kubectl') {

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -64,10 +64,13 @@ pipeline {
         expression {
           return env.DEPLOYMENTSTRATEGY ==~ 'blue_green_service' 
         }
-      }
+      }      
       steps {
-        container('helm') {
-          sh "helm init --client-only"
+        container('kubectl') {
+          sh "echo ${env.PROJECT}"
+        }
+        container('helm') {        
+          sh "helm init --client-only"          
           sh "cd ${env.PROJECT} && helm dep update helm-chart/"
           sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
         }

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -67,19 +67,23 @@ pipeline {
       }      
       steps {
         container('yq') {
-            def c1 = sh(script: 'cat ${env.PROJECT}/helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml | yq r - spec.http[0].route[0].destination.subset', returnStdout: true)
-            def w1 = sh(script: 'cat ${env.PROJECT}/helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml | yq r - spec.http[0].route[0].weight', returnStdout: true)
-            def c2 = sh(script: 'cat ${env.PROJECT}/helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml | yq r - spec.http[0].route[1].destination.subset', returnStdout: true)
-            def w2 = sh(script: 'cat ${env.PROJECT}/helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml | yq r - spec.http[0].route[1].weight', returnStdout: true)
+            script {
+                def c1 = sh(script: 'cat ${env.PROJECT}/helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml | yq r - spec.http[0].route[0].destination.subset', returnStdout: true)
+                def w1 = sh(script: 'cat ${env.PROJECT}/helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml | yq r - spec.http[0].route[0].weight', returnStdout: true)
+                def c2 = sh(script: 'cat ${env.PROJECT}/helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml | yq r - spec.http[0].route[1].destination.subset', returnStdout: true)
+                def w2 = sh(script: 'cat ${env.PROJECT}/helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml | yq r - spec.http[0].route[1].weight', returnStdout: true)
+            }
         }
 
         container('kubectl') {
-            if (w1 == "100") {
-                print "Delete doployment of " + "${env.SERVICE}" + c1
-            } else if (w2 == "100") {
-                print "Delete doployment of " + "${env.SERVICE}" + c2
-            } else {
-                print "This case must not happen!"
+            script {
+                if (w1 == "100") {
+                    println "Delete doployment of " + "${env.SERVICE}" + c1
+                } else if (w2 == "100") {
+                    println "Delete doployment of " + "${env.SERVICE}" + c2
+                } else {
+                    println "This case must not happen!"
+                }
             }
         }
         container('helm') {        

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -73,16 +73,16 @@ pipeline {
             sh "helm init --client-only"
             sh "cd ${env.PROJECT} && helm dep update helm-chart/"
 
-            sh "find ${env.PROJECT}/helm-chart/templates -name '*istio-virtual-service*' -print > istioFiles"
-            for (String file : readFile('istioFiles').split()) {
-              String mvCmd = "mv " + files + " " + "${env.PROJECT}" + "/helm-chart/"
+            sh "find ${env.PROJECT}/helm-chart/templates -name '*istio-virtual-service*' -print > istioVSFiles"
+            for (String file : readFile('istioVSFiles').split()) {
+              String mvCmd = "mv " + file + " " + "${env.PROJECT}" + "/helm-chart/"
               println mvCmd
               sh(script: mvCmd)
             }
             sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
 
-            sh "find ${env.PROJECT}/helm-chart -name '*istio-virtual-service*' -print > istioFiles"
-            for (String file : readFile('istioFiles').split()) {
+            sh "find ${env.PROJECT}/helm-chart -name '*istio-virtual-service*' -print > istioVSFiles"
+            for (String file : readFile('istioVSFiles').split()) {
               String mvCmd = "mv " + file + " " + "${env.PROJECT}" + "/helm-chart/templates/"
               println mvCmd
               sh(script: mvCmd)

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -70,10 +70,10 @@ pipeline {
           sh "helm init --client-only"
           sh "cd ${env.PROJECT} && helm dep update helm-chart/"
           
-          sh "cd ${env.PROJECT}/helm-chart/templates && find . -name '*istio-virtual-service*' -print | xargs -J% mv % ../"
+          sh "cd ${env.PROJECT}/helm-chart/templates && for i in $(find . -name '*istio-virtual-service*' -print ); do mv "$i" ../; done"
           sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
           
-          sh "cd ${env.PROJECT}/helm-chart && find . -name '*istio-virtual-service*' -print | xargs -J% mv % templates/"
+          sh "cd ${env.PROJECT}/helm-chart && for i in $(find . -name '*istio-virtual-service*' -print ); do mv "$i" templates/; done"
           sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
         }
       }

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -74,7 +74,7 @@ pipeline {
         }
 
         container('kubectl') {
-            sh "echo "Service=" ${env.SERVICE}"
+            sh "echo ${env.SERVICE}"
         }
         container('helm') {        
           sh "helm init --client-only"          

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -67,14 +67,14 @@ pipeline {
       }      
       steps {
         container('yq') {
-            sh "COLOR1=$(cat carts-istio-virtual-service.yaml | yq r - spec.http[0].route[0].destination.subset)"
-            sh "WEIGHT1=$(cat carts-istio-virtual-service.yaml | yq r - spec.http[0].route[0].weight)"
-            sh "COLOR2=$(cat carts-istio-virtual-service.yaml | yq r - spec.http[0].route[1].destination.subset)"
-            sh "WEIGHT2=$(cat carts-istio-virtual-service.yaml | yq r - spec.http[0].route[1].weight)"
+            sh "echo "COLOR1" $(cat carts-istio-virtual-service.yaml | yq r - spec.http[0].route[0].destination.subset)"
+            sh "echo "WEIGHT1" $(cat carts-istio-virtual-service.yaml | yq r - spec.http[0].route[0].weight)"
+            sh "echo "COLOR2" $(cat carts-istio-virtual-service.yaml | yq r - spec.http[0].route[1].destination.subset)"
+            sh "echo "WEIGHT2" $(cat carts-istio-virtual-service.yaml | yq r - spec.http[0].route[1].weight)"
         }
 
         container('kubectl') {
-            sh "if [ $WEIGHT1 == "100" ]; then echo "Delete doployment of" $COLOR1; echo "Service=" ${env.SERVICE}; elif [$WEIGHT2 == "100" ]; then echo "Delete doployment of" $COLOR2; echo "Service=" ${env.SERVICE}; else  echo "This case must not happen!"; fi"
+            sh "echo "Service=" ${env.SERVICE}"
         }
         container('helm') {        
           sh "helm init --client-only"          

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -66,8 +66,21 @@ pipeline {
         }
       }      
       steps {
+        container('yq') {
+            def c1 = sh(script: 'cat ${env.PROJECT}/helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml | yq r - spec.http[0].route[0].destination.subset', returnStdout: true)
+            def w1 = sh(script: 'cat ${env.PROJECT}/helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml | yq r - spec.http[0].route[0].weight', returnStdout: true)
+            def c2 = sh(script: 'cat ${env.PROJECT}/helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml | yq r - spec.http[0].route[1].destination.subset', returnStdout: true)
+            def w2 = sh(script: 'cat ${env.PROJECT}/helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml | yq r - spec.http[0].route[1].weight', returnStdout: true)
+        }
+
         container('kubectl') {
-            sh "echo ${env.SERVICE}"
+            if (w1 == "100") {
+                print "Delete doployment of " + "${env.SERVICE}" + c1
+            } else if (w2 == "100") {
+                print "Delete doployment of " + "${env.SERVICE}" + c2
+            } else {
+                print "This case must not happen!"
+            }
         }
         container('helm') {        
           sh "helm init --client-only"          

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -70,10 +70,22 @@ pipeline {
           sh "helm init --client-only"
           sh "cd ${env.PROJECT} && helm dep update helm-chart/"
           
-          sh '''cd ${env.PROJECT}/helm-chart/templates && for i in $(find . -name '*istio-virtual-service*' -print ); do mv "$i" ../; done'''
+          final foundFiles = sh(script: 'find ${env.PROJECT}/helm-chart/templates -name '*istio-virtual-service*' -print', returnStdout: true).split()
+          for (String file : foundFiles) {
+            String mvCmd = "mv " + foundFiles + " " + "${env.PROJECT}" + "/helm-chart/"
+            println mvCmd
+            sh(script: mvCmd)
+          }
+          
           sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
           
-          sh '''cd ${env.PROJECT}/helm-chart && for i in $(find . -name '*istio-virtual-service*' -print ); do mv "$i" templates/; done'''
+          final foundFilesTmp = sh(script: 'find ${env.PROJECT}/helm-chart -name '*istio-virtual-service*' -print', returnStdout: true).split()
+          for (String file : foundFilesTmp) {
+            String mvCmd = "mv " + file + " " + "${env.PROJECT}" + "/helm-chart/templates"
+            println mvCmd
+            sh(script: mvCmd)
+          }
+    
           sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
         }
       }

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -69,21 +69,18 @@ pipeline {
         container('yq') {
             script {
                 sh "cat ${env.PROJECT}/helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml > vs"
-                def c1 = sh(script: 'yq r vs spec.http[0].route[0].destination.subset', returnStdout: true)
-                println c1
-                def w1 = sh(script: 'yq r vs spec.http[0].route[0].weight', returnStdout: true)
-                println w1
-                def c2 = sh(script: 'yq r vs spec.http[0].route[1].destination.subset', returnStdout: true)
-                println c2
-                def w2 = sh(script: 'yq r vs spec.http[0].route[1].weight', returnStdout: true)
-                println w2
+                sh "yq r vs spec.http[0].route[0].destination.subset > c1"
+                sh "yq r vs spec.http[0].route[0].weight > w1"
+                sh "yq r vs spec.http[0].route[1].destination.subset > c2"
+                sh "yq r vs spec.http[0].route[1].weight > w2"
             }
         }
+
         container('kubectl') {
             script {
-                if (w1 == "100") {
+                if (readFile('w1').trim() == "100") {
                     println "Delete doployment of " + "${env.SERVICE}" + c1
-                } else if (w2 == "100") {
+                } else if (readFile('w2').trim() == "100") {
                     println "Delete doployment of " + "${env.SERVICE}" + c2
                 } else {
                     println "This case must not happen!"

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -70,10 +70,10 @@ pipeline {
           sh "helm init --client-only"
           sh "cd ${env.PROJECT} && helm dep update helm-chart/"
           
-          sh "cd ${env.PROJECT}/helm-chart/templates && for i in $(find . -name '*istio-virtual-service*' -print ); do mv "$i" ../; done"
+          sh '''cd ${env.PROJECT}/helm-chart/templates && for i in $(find . -name '*istio-virtual-service*' -print ); do mv "$i" ../; done'''
           sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
           
-          sh "cd ${env.PROJECT}/helm-chart && for i in $(find . -name '*istio-virtual-service*' -print ); do mv "$i" templates/; done"
+          sh '''cd ${env.PROJECT}/helm-chart && for i in $(find . -name '*istio-virtual-service*' -print ); do mv "$i" templates/; done'''
           sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
         }
       }

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -55,7 +55,7 @@ pipeline {
         container('helm') {
           sh "helm init --client-only"
           sh "cd ${env.PROJECT} && helm dep update helm-chart/"
-          sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --recreate-pods"
+          sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE}"
         }
       }
     }
@@ -69,7 +69,7 @@ pipeline {
         container('helm') {
           sh "helm init --client-only"
           sh "cd ${env.PROJECT} && helm dep update helm-chart/"
-          sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --recreate-pods"
+          sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE}"
         }
       }
     }

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -67,10 +67,10 @@ pipeline {
       }      
       steps {
         container('yq') {
-            sh "cat carts-istio-virtual-service.yaml | yq r - spec.http[0].route[0].destination.subset"
-            sh "cat carts-istio-virtual-service.yaml | yq r - spec.http[0].route[0].weight"
-            sh "cat carts-istio-virtual-service.yaml | yq r - spec.http[0].route[1].destination.subset"
-            sh "cat carts-istio-virtual-service.yaml | yq r - spec.http[0].route[1].weight"
+            sh "cat ./helm-chart/carts-istio-virtual-service.yaml | yq r - spec.http[0].route[0].destination.subset"
+            sh "cat ./helm-chart/carts-istio-virtual-service.yaml | yq r - spec.http[0].route[0].weight"
+            sh "cat ./helm-chart/carts-istio-virtual-service.yaml | yq r - spec.http[0].route[1].destination.subset"
+            sh "cat ./helm-chart/carts-istio-virtual-service.yaml | yq r - spec.http[0].route[1].weight"
         }
 
         container('kubectl') {

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -70,10 +70,10 @@ pipeline {
           sh "helm init --client-only"
           sh "cd ${env.PROJECT} && helm dep update helm-chart/"
           
-          sh "cd ${env.PROJECT}/helm-chart/templates && find . -name '*istio-virtual-service*' -exec mv {} ../ \;"
+          sh "cd ${env.PROJECT}/helm-chart/templates && find . -name '*istio-virtual-service*' -print | xargs -J% mv % ../"
           sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
           
-          sh "cd ${env.PROJECT}/helm-chart && find . -name '*istio-virtual-service*' -exec mv {} ./templates \;"
+          sh "cd ${env.PROJECT}/helm-chart && find . -name '*istio-virtual-service*' -print | xargs -J% mv % templates/"
           sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
         }
       }

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -68,14 +68,15 @@ pipeline {
       steps {
         container('yq') {
             script {
-                sh "pwd"
-                sh "echo ${env.PROJECT}/helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml"
                 sh "cat ${env.PROJECT}/helm-chart/templates/${env.SERVICE}-istio-virtual-service.yaml > vs"
-
                 def c1 = sh(script: 'yq r vs spec.http[0].route[0].destination.subset', returnStdout: true)
+                println c1
                 def w1 = sh(script: 'yq r vs spec.http[0].route[0].weight', returnStdout: true)
+                println w1
                 def c2 = sh(script: 'yq r vs spec.http[0].route[1].destination.subset', returnStdout: true)
+                println c2
                 def w2 = sh(script: 'yq r vs spec.http[0].route[1].weight', returnStdout: true)
+                println w2
             }
         }
         container('kubectl') {

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -53,16 +53,18 @@ pipeline {
       }
       steps {
         container('helm') {
-          sh "helm init --client-only"
-          
-          sh "find ${env.PROJECT}/helm-chart -name '*istio-virtual-service*' -print > istioFiles"
-          for (String file : readFile('istioFiles').split()) {
-            String mvCmd = "mv " + file + " " + "${env.PROJECT}" + "/helm-chart/templates"
-            println mvCmd
+          script {
+            sh "helm init --client-only"
+
+            sh "find ${env.PROJECT}/helm-chart -name '*istio-virtual-service*' -print > istioFiles"
+            for (String file : readFile('istioFiles').split()) {
+              String mvCmd = "mv " + file + " " + "${env.PROJECT}" + "/helm-chart/templates"
+              println mvCmd
+            }
+
+            sh "cd ${env.PROJECT} && helm dep update helm-chart/"
+            sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
           }
-            
-          sh "cd ${env.PROJECT} && helm dep update helm-chart/"
-          sh "cd ${env.PROJECT} && helm upgrade --install ${env.PROJECT}-${env.STAGE} ./helm-chart --namespace ${env.PROJECT}-${env.STAGE} --wait"
         }
       }
     }


### PR DESCRIPTION
Use of a multi-step approach for b/g deployments in the deploy-Pipeline, which 
1. checks out the config repo,
2. switches back to a version containing only changes of the Helm-values file (i.e. contains deployment changes),
3. applies these changes with helm upgrade,
4. waits for the rollout to be finished,
5. checks out Istio-virtual-service changes, and
6. apply these changes with helm upgrade

Further changes:
- readiness and liveness probes are added to the deployment template
- in the github-service, the order of the commits of the values and istio-virtual-service files in the config repo had to be changed.

Going forward, the configuration-changed event will contain the Git commit hashes, which have to be sequentially applied in the deploy pipeline. By this, we will also address the known limitation described in #360.
