### PR TITLE
#387 Fixed typo: Changed artefact to artifact

### DIFF
--- a/pipelines/Jenkinsfile.evaluation_done
+++ b/pipelines/Jenkinsfile.evaluation_done
@@ -43,7 +43,7 @@ pipeline {
           container("curl") {
             sendCloudEvent(
               receiver: 'event-broker.keptn.svc.cluster.local/keptn',
-              type: 'sh.keptn.events.new-artefact',
+              type: 'sh.keptn.events.new-artifact',
               source: 'Jenkins',
               shkeptncontext : "${env.KEPTNCONTEXT}",
               data: [

--- a/releasenotes/releasenotes_V0.3.0.md
+++ b/releasenotes/releasenotes_V0.3.0.md
@@ -1,4 +1,4 @@
-# Release Notes 0.2.1
+# Release Notes 0.3.0
 
 ## New Features
 - new Jenkins image: keptn/jenkins:0.6.0

--- a/releasenotes/releasenotes_develop.md
+++ b/releasenotes/releasenotes_develop.md
@@ -1,7 +1,8 @@
-# Release Notes develop
+# Release Notes x.x.x
 
 ## New Features
 
 ## Fixed Issues
+- Fixed typo: Changed _art**e**fact_ to _art**i**fact_ [#387](https://github.com/keptn/keptn/issues/387)
 
 ## Known Limitations


### PR DESCRIPTION
This PR ensures a consistent use of the word artifact instead of artefact across all keptn repositories.